### PR TITLE
Add bogus, custom benchmarks

### DIFF
--- a/src/Funtom.Linq.Performance/Funtom.Linq.Performance.fsproj
+++ b/src/Funtom.Linq.Performance/Funtom.Linq.Performance.fsproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Bogus" Version="34.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Funtom.Linq.Performance/Program.fs
+++ b/src/Funtom.Linq.Performance/Program.fs
@@ -4,13 +4,32 @@ open Funtom.Linq
 open System.Linq
 open System
 open System.Collections
+open Bogus
 
+let fake = Faker()
+
+[<PlainExporter; MemoryDiagnoser>]
 type Benchmark () =
-  let xs = [ 0..10000 ]
-  let ys = [| 0..10000 |]
-  let zs = ResizeArray [| 0..10000 |]
-  let ss = seq { 0..10000 }
+//  let xs = [ 0..10000 ]
+//  let ys = [| 0..10000 |]
+//  let zs = ResizeArray [| 0..10000 |]
+//  let ss = seq { 0..10000 }
   
+  
+  
+  let mutable xs = List.empty
+  let mutable ys = Array.empty
+  let mutable zs = ResizeArray()
+  let mutable ss = Seq.empty
+  
+  
+  
+  [<GlobalSetup>]
+    member this.Setup() =
+        xs <- [for _ in 1..10000 do fake.Random.Int()]
+        ys <- [|for _ in 1..10000 do fake.Random.Int()|]
+        zs <- ResizeArray([|for _ in 1..10000 do fake.Random.Int()|])
+        ss <- [|for _ in 1..10000 do fake.Random.Int()|] |> Seq.ofArray
 
   //[<Benchmark>]
   //member __.System_Linq_append_fslist() =
@@ -54,76 +73,76 @@ type Benchmark () =
   //    acc <- acc + z
   //  acc
 
+//  [<Benchmark>]
+//  member __.System_Linq_append_seq() =
+//    let mutable acc = 0
+//    for s in ss.Append(10) do
+//      acc <- acc + s
+//    acc
+//
+//  [<Benchmark>]
+//  member __.Funtom_Linq_append_seq() =
+//    let mutable acc = 0
+//    for s in ss |> Linq.append 10 do
+//      acc <- acc + s
+//    acc
+
+
   [<Benchmark>]
-  member __.System_Linq_append_seq() =
+  member __.System_Linq_select_fslist() =
     let mutable acc = 0
-    for s in ss.Append(10) do
+    for x in xs.Select(fun v -> v / 2) do
+      acc <- acc + x
+    acc
+
+  [<Benchmark>]
+  member __.Funtom_Linq_select_fslist() =
+    let mutable acc = 0
+    for x in xs |> Linq.select (fun v -> v / 2) do
+      acc <- acc + x
+    acc
+    
+  [<Benchmark>]
+  member __.System_Linq_select_array() =
+    let mutable acc = 0
+    for y in ys.Select(fun v -> v / 2) do
+      acc <- acc + y
+    acc
+
+  [<Benchmark>]
+  member __.Funtom_Linq_select_array() =
+    let mutable acc = 0
+    for y in ys |> Linq.select (fun v -> v / 2) do
+      acc <- acc + y
+    acc
+    
+  [<Benchmark>]
+  member __.System_Linq_select_resizearray() =
+    let mutable acc = 0
+    for z in zs.Select(fun v -> v / 2) do
+      acc <- acc + z
+    acc
+
+  [<Benchmark>]
+  member __.Funtom_Linq_select_resizearray() =
+    let mutable acc = 0
+    for z in zs |> Linq.select (fun v -> v / 2) do
+      acc <- acc + z
+    acc
+
+  [<Benchmark>]
+  member __.System_Linq_select_seq() =
+    let mutable acc = 0
+    for s in ss.Select(fun v -> v / 2) do
       acc <- acc + s
     acc
 
   [<Benchmark>]
-  member __.Funtom_Linq_append_seq() =
+  member __.Funtom_Linq_select_seq() =
     let mutable acc = 0
-    for s in ss |> Linq.append 10 do
+    for s in ss |> Linq.select (fun v -> v / 2) do
       acc <- acc + s
     acc
-
-
-  //[<Benchmark>]
-  //member __.System_Linq_select_fslist() =
-  //  let mutable acc = 0
-  //  for x in xs.Select(fun v -> v) do
-  //    acc <- acc + x
-  //  acc
-
-  //[<Benchmark>]
-  //member __.Funtom_Linq_select_fslist() =
-  //  let mutable acc = 0
-  //  for x in xs |> Linq.select (fun v -> v) do
-  //    acc <- acc + x
-  //  acc
-    
-  //[<Benchmark>]
-  //member __.System_Linq_select_array() =
-  //  let mutable acc = 0
-  //  for y in ys.Select(fun v -> v) do
-  //    acc <- acc + y
-  //  acc
-
-  //[<Benchmark>]
-  //member __.Funtom_Linq_select_array() =
-  //  let mutable acc = 0
-  //  for y in ys |> Linq.select (fun v -> v) do
-  //    acc <- acc + y
-  //  acc
-    
-  //[<Benchmark>]
-  //member __.System_Linq_append_resizearray() =
-  //  let mutable acc = 0
-  //  for z in zs.Select(fun v -> v) do
-  //    acc <- acc + z
-  //  acc
-
-  //[<Benchmark>]
-  //member __.Funtom_Linq_select_resizearray() =
-  //  let mutable acc = 0
-  //  for z in zs |> Linq.select (fun v -> v) do
-  //    acc <- acc + z
-  //  acc
-
-  //[<Benchmark>]
-  //member __.System_Linq_select_seq() =
-  //  let mutable acc = 0
-  //  for s in ss.Select(fun v -> v) do
-  //    acc <- acc + s
-  //  acc
-
-  //[<Benchmark>]
-  //member __.Funtom_Linq_select_seq() =
-  //  let mutable acc = 0
-  //  for s in ss |> Linq.select (fun v -> v) do
-  //    acc <- acc + s
-  //  acc
   
   
   //[<Benchmark>]

--- a/src/Funtom.Linq.Performance/Program.fs
+++ b/src/Funtom.Linq.Performance/Program.fs
@@ -102,6 +102,14 @@ type Benchmark () =
       acc <- acc + x
     acc
     
+    
+  [<Benchmark>]
+  member __.Fsharp_map_fslist() =
+    let mutable acc = 0
+    for x in xs |> List.map (fun v -> v / 2) do
+      acc <- acc + x
+    acc
+  
   [<Benchmark>]
   member __.System_Linq_select_array() =
     let mutable acc = 0
@@ -113,6 +121,13 @@ type Benchmark () =
   member __.Funtom_Linq_select_array() =
     let mutable acc = 0
     for y in ys |> Linq.select (fun v -> v / 2) do
+      acc <- acc + y
+    acc
+    
+  [<Benchmark>]
+  member __.Fsharp_map_array() =
+    let mutable acc = 0
+    for y in ys |> Array.map (fun v -> v / 2) do
       acc <- acc + y
     acc
     
@@ -144,6 +159,12 @@ type Benchmark () =
       acc <- acc + s
     acc
   
+  [<Benchmark>]
+  member __.Fsharp_map_seq() =
+    let mutable acc = 0
+    for s in ss |> Seq.map (fun v -> v / 2) do
+      acc <- acc + s
+    acc
   
   //[<Benchmark>]
   //member __.System_Linq_aggregate_fslist() =


### PR DESCRIPTION
Hello, I've structured the setup step a bit, and added MemoryDiagnoser to see the allocations clearly (which is important in this case).

Also, It would be very nice to have standard FSharp.Core methods like Array.map, Seq.map, List.map next to their linq counterparts.
I've got the following results running it:
```
BenchmarkDotNet=v0.13.1, OS=macOS Big Sur 11.4 (20F71) [Darwin 20.5.0]
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT DEBUG
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
```

|                         Method |      Mean |    Error |   StdDev |    Median | Allocated |
|------------------------------- |----------:|---------:|---------:|----------:|----------:|
|      System_Linq_select_fslist | 207.16 us | 3.001 us | 2.506 us | 206.65 us |     160 B |
|      Funtom_Linq_select_fslist | 103.02 us | 0.848 us | 0.751 us | 103.12 us |      40 B |
|       System_Linq_select_array |  81.00 us | 1.336 us | 2.510 us |  79.80 us |     112 B |
|       Funtom_Linq_select_array |  69.61 us | 0.303 us | 0.253 us |  69.54 us |      72 B |
| System_Linq_select_resizearray | 105.14 us | 0.379 us | 0.355 us | 105.05 us |     136 B |
| Funtom_Linq_select_resizearray |  67.09 us | 1.053 us | 0.985 us |  66.73 us |      48 B |
|         System_Linq_select_seq | 138.79 us | 0.684 us | 0.606 us | 138.64 us |     152 B |
|         Funtom_Linq_select_seq | 154.78 us | 0.916 us | 0.857 us | 154.74 us |     152 B |

Please tell me your opinion on this.

